### PR TITLE
Serializer interface adjustments to support multiple object classes

### DIFF
--- a/src/client/model/Serializer.java
+++ b/src/client/model/Serializer.java
@@ -5,6 +5,8 @@
  */
 package client.model;
 
+import shared.models.*;
+
 /**
  * Serializer interface describes the API for converting JSON to Java objects. 
  * This interface serializes the JSON if it is a valid representation of the 
@@ -21,7 +23,7 @@ public interface Serializer {
      * model using Java objects. This method will return null if the the JSON 
      * parameter was not valid (null, missing fields, etc).
      */
-    ModelContainer deserialize(String JSON);
+    ModelContainer deserializeModel(String JSON);
     
     /**
      * Converts a Java object representation of the model into a JSON 
@@ -33,5 +35,127 @@ public interface Serializer {
      * JSON. This method will return null if the the container parameter was
      * not valid (null, missing fields, etc).
      */
-    String serialize(ModelContainer container);
+    String serializeModel(ModelContainer container);
+    
+    /**
+     * Converts a JSON string into <code>User</code> Object. 
+     * @pre requires the JSON string to be a valid representation of the User object
+     * @param JSON A valid representation of the User Object in JSON.
+     * @return A <code>User</code> object. This method will return null if the the JSON 
+     * parameter was not valid (null, missing fields, etc).
+     */
+    User deserializeUser(String JSON);
+    
+    /**
+     * Converts a Java object representation of the User object into a JSON 
+     * representation. 
+     * @pre requires the Java object to be a valid representation of the User object
+     * @param user A valid representation of the User object in Java.
+     * @return A JSON string that represents the User object using 
+     * JSON. This method will return null if the the parameter was
+     * not valid (null, missing fields, etc).
+     */
+    String serializeUser(User user);
+    
+    /**
+     * Converts a JSON string into <code>GameContainer</code> Object. 
+     * @pre requires the JSON string to be a valid representation of the GameContainer object
+     * @param JSON A valid representation of the GameContainer object in JSON.
+     * @return A <code>GameContainer</code> object. This method will return null if the the JSON 
+     * parameter was not valid (null, missing fields, etc).
+     */
+    GameContainer deserializeGameContainer(String JSON);
+    
+    /**
+     * Converts a Java object representation of the GameContainer object into a JSON 
+     * representation. 
+     * @pre requires the Java object to be a valid representation of the GameContainer object
+     * @param user A valid representation of the GameContainer object in Java.
+     * @return A JSON string that represents the GameContainer object using 
+     * JSON. This method will return null if the the parameter was
+     * not valid (null, missing fields, etc).
+     */
+    String serializeGameContainer(GameContainer games);
+    
+    /**
+     * Converts a JSON string into <code>Game</code> Object. 
+     * @pre requires the JSON string to be a valid representation of the Game object
+     * @param JSON A valid representation of the Game object in JSON.
+     * @return A <code>Game</code> object. This method will return null if the the JSON 
+     * parameter was not valid (null, missing fields, etc).
+     */
+    Game deserializeGame(String JSON);
+    
+    /**
+     * Converts a Java object representation of the Game object into a JSON 
+     * representation. 
+     * @pre requires the Java object to be a valid representation of the Game object
+     * @param user A valid representation of the Game object in Java.
+     * @return A JSON string that represents the Game object using 
+     * JSON. This method will return null if the the parameter was
+     * not valid (null, missing fields, etc).
+     */
+    String serializeGame(Game game);
+    
+    /**
+     * Converts a JSON string into <code>CommandContainer</code> Object. 
+     * @pre requires the JSON string to be a valid representation of the CommandContainer object
+     * @param JSON A valid representation of the CommandContainer object in JSON.
+     * @return A <code>CommandContainer</code> object. This method will return null if the the JSON 
+     * parameter was not valid (null, missing fields, etc).
+     */
+    CommandContainer deserializeCommandContainer(String JSON);
+    
+    /**
+     * Converts a Java object representation of the CommandContainer object into a JSON 
+     * representation. 
+     * @pre requires the Java object to be a valid representation of the CommandContainer object
+     * @param user A valid representation of the CommandContainer object in Java.
+     * @return A JSON string that represents the CommandContainer object using 
+     * JSON. This method will return null if the the parameter was
+     * not valid (null, missing fields, etc).
+     */
+    String serializeCommandContainer(CommandContainer commands);
+    
+    /**
+     * Converts a JSON string into <code>AITypesContainer</code> Object. 
+     * @pre requires the JSON string to be a valid representation of the AITypesContainer object
+     * @param JSON A valid representation of the AITypesContainer object in JSON.
+     * @return An <code>AITypesContainer</code> object. This method will return null if the the JSON 
+     * parameter was not valid (null, missing fields, etc).
+     */
+    AITypesContainer deserializeAITypesContainer(String JSON);
+    
+    /**
+     * Converts a Java object representation of the AITypesContainer object into a JSON 
+     * representation. 
+     * @pre requires the Java object to be a valid representation of the AITypesContainer object
+     * @param user A valid representation of the AITypesContainer object in Java.
+     * @return A JSON string that represents the AITypesContainer object using 
+     * JSON. This method will return null if the the parameter was
+     * not valid (null, missing fields, etc).
+     */
+    String serializeAITypesContainer(AITypesContainer aIplayers);
+    
+    /**
+     * Converts a JSON string into <code>AIPlayer</code> Object. 
+     * @pre requires the JSON string to be a valid representation of the AIPlayer object
+     * @param JSON A valid representation of the AIPlayer object in JSON.
+     * @return An <code>AIPlayer</code> object. This method will return null if the the JSON 
+     * parameter was not valid (null, missing fields, etc).
+     */
+    AIPlayer deserializeAIPlayer(String JSON);
+    
+    /**
+     * Converts a Java object representation of the AIPlayer object into a JSON 
+     * representation. 
+     * @pre requires the Java object to be a valid representation of the AIPlayer object
+     * @param user A valid representation of the AIPlayer object in Java.
+     * @return A JSON string that represents the AIPlayer object using 
+     * JSON. This method will return null if the the parameter was
+     * not valid (null, missing fields, etc).
+     */
+    String serializeAIPlayer(AIPlayer aIplayer);
+    
+    
 }

--- a/src/client/network/MockServerProxy.java
+++ b/src/client/network/MockServerProxy.java
@@ -6,14 +6,13 @@
 package client.network;
 
 import java.io.IOException;
+
 import shared.definitions.CatanColor;
 import shared.definitions.ResourceType;
 import shared.locations.EdgeLocation;
 import shared.locations.HexLocation;
 import shared.locations.VertexLocation;
-import shared.models.Game;
-import shared.models.GameContainer;
-import shared.models.ResourceList;
+import shared.models.*;
 
 /**
  * MockServerProxy is a mock implementation of iServerProxy. This class
@@ -58,7 +57,7 @@ public class MockServerProxy implements iServerProxy {
     }
 
     @Override
-    public void offerTrade(ResourceList offer, int reciever) throws IOException {
+    public void offerTrade(TradeOffer offer) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -108,12 +107,12 @@ public class MockServerProxy implements iServerProxy {
     }
 
     @Override
-    public void login(String username, String password) throws IOException {
+    public User login(String username, String password) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void registerNewUser(String username, String password) throws IOException {
+    public User registerNewUser(String username, String password) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -128,12 +127,12 @@ public class MockServerProxy implements iServerProxy {
     }
 
     @Override
-    public void joinGame(int gameId, CatanColor color) throws IOException {
+    public User joinGame(int gameId, CatanColor color) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void saveGames(int gameId, String fileName) throws IOException {
+    public boolean saveGames(int gameId, String fileName) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -153,22 +152,22 @@ public class MockServerProxy implements iServerProxy {
     }
 
     @Override
-    public void getCommands() throws IOException {
+    public CommandContainer getCommands() throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void postGameCommands() throws IOException {
+    public void postGameCommands(CommandContainer commands) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void listAITypes() throws IOException {
+    public AITypesContainer listAITypes() throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void addAIPlayer() throws IOException {
+    public void addAIPlayer(AIPlayer player) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/src/client/network/ServerPoller.java
+++ b/src/client/network/ServerPoller.java
@@ -101,7 +101,7 @@ public class ServerPoller implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         String newModel = poll();
         if (isNew(newModel)) {
-            ModelContainer container = serializer.deserialize(newModel);
+            ModelContainer container = serializer.deserializeModel(newModel);
             updateModel(container);
         }
     }

--- a/src/client/network/ServerProxy.java
+++ b/src/client/network/ServerProxy.java
@@ -6,14 +6,20 @@
 package client.network;
 
 import java.io.IOException;
+
 import shared.definitions.CatanColor;
 import shared.definitions.ResourceType;
 import shared.locations.EdgeLocation;
 import shared.locations.HexLocation;
 import shared.locations.VertexLocation;
+import shared.models.AIPlayer;
+import shared.models.AITypesContainer;
+import shared.models.CommandContainer;
 import shared.models.Game;
 import shared.models.GameContainer;
 import shared.models.ResourceList;
+import shared.models.TradeOffer;
+import shared.models.User;
 
 /**
  * ServerProxy is our implementation of the iServerProxy interface.
@@ -21,6 +27,7 @@ import shared.models.ResourceList;
  * @author Peter Anderson <anderson.peter@byu.edu>
  */
 public class ServerProxy implements iServerProxy {
+
 
     @Override
     public void sendChat(String content) throws IOException {
@@ -58,7 +65,7 @@ public class ServerProxy implements iServerProxy {
     }
 
     @Override
-    public void offerTrade(ResourceList offer, int reciever) throws IOException {
+    public void offerTrade(TradeOffer offer) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -108,12 +115,12 @@ public class ServerProxy implements iServerProxy {
     }
 
     @Override
-    public void login(String username, String password) throws IOException {
+    public User login(String username, String password) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void registerNewUser(String username, String password) throws IOException {
+    public User registerNewUser(String username, String password) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -128,12 +135,12 @@ public class ServerProxy implements iServerProxy {
     }
 
     @Override
-    public void joinGame(int gameId, CatanColor color) throws IOException {
+    public User joinGame(int gameId, CatanColor color) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void saveGames(int gameId, String fileName) throws IOException {
+    public boolean saveGames(int gameId, String fileName) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -153,22 +160,22 @@ public class ServerProxy implements iServerProxy {
     }
 
     @Override
-    public void getCommands() throws IOException {
+    public CommandContainer getCommands() throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void postGameCommands() throws IOException {
+    public void postGameCommands(CommandContainer commands) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void listAITypes() throws IOException {
+    public AITypesContainer listAITypes() throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
-    public void addAIPlayer() throws IOException {
+    public void addAIPlayer(AIPlayer player) throws IOException {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
@@ -178,3 +185,4 @@ public class ServerProxy implements iServerProxy {
     }
     
 }
+

--- a/src/client/network/iServerProxy.java
+++ b/src/client/network/iServerProxy.java
@@ -12,9 +12,7 @@ import shared.definitions.ResourceType;
 import shared.locations.EdgeLocation;
 import shared.locations.HexLocation;
 import shared.locations.VertexLocation;
-import shared.models.Game;
-import shared.models.GameContainer;
-import shared.models.ResourceList;
+import shared.models.*;
 
 /**
  *
@@ -95,11 +93,10 @@ public interface iServerProxy {
 	 * @pre It is the players turn or the player is offering to the player whose turn it currently is
 	 * @pre the player has the resources they are offering
 	 * @post the player is notified with the resources up for trade and the model is updated
-	 * @param offer
-	 * @param reciever
+	 * @param tradeOffer the information about the offer
 	 * @throws IOException
 	 */
-	void offerTrade(ResourceList offer, int reciever) throws IOException;
+	void offerTrade(TradeOffer tradeOffer) throws IOException;
 	
 	/**
 	 * Sends a request to the server to offer a maritimetrade
@@ -206,9 +203,10 @@ public interface iServerProxy {
 	 * @post the player is logged in and assigned a color and the model is updated
 	 * @param username
 	 * @param password
+	 * @return user 
 	 * @throws IOException
 	 */
-	void login(String username, String password) throws IOException;
+	User login(String username, String password) throws IOException;
 	
 	/**
 	 * Sends a request to the server to register a new user
@@ -217,9 +215,10 @@ public interface iServerProxy {
 	 * @post user created and the model is updated
 	 * @param username
 	 * @param password
+	 * @return user 
 	 * @throws IOException
 	 */
-	void registerNewUser(String username, String password) throws IOException;
+	User registerNewUser(String username, String password) throws IOException;
 	
 	/**
 	 * Sends a request to the server to list the games
@@ -253,7 +252,7 @@ public interface iServerProxy {
 	 * @param color
 	 * @throws IOException
 	 */
-	void joinGame(int gameId, CatanColor color) throws IOException;
+	User joinGame(int gameId, CatanColor color) throws IOException;
 	
 	/**
 	 * Sends a request to the server to save a game
@@ -264,7 +263,7 @@ public interface iServerProxy {
 	 * @param fileName
 	 * @throws IOException
 	 */
-	void saveGames(int gameId, String fileName) throws IOException;
+	boolean saveGames(int gameId, String fileName) throws IOException;
 	
 	/**
 	 * Sends a request to the server to load a game
@@ -298,22 +297,23 @@ public interface iServerProxy {
 	 * @post a list of commands is retrieved
 	 * @throws IOException
 	 */
-	void getCommands() throws IOException;
+	CommandContainer getCommands() throws IOException;
 	
 	/**
-	 * Sends a request to server to get a list of the post game commands
+	 * Sends a request to server with a list of the game commands
 	 * @pre a user is logged in and has joined a game
-	 * @post a list of commands is retrieved
+	 * @pre 
+	 * @post a list of commands is sent to the server
 	 * @throws IOException
 	 */
-	void postGameCommands() throws IOException;
+	void postGameCommands(CommandContainer commands) throws IOException;
 	
 	/**
 	 * Sends a request to the server to list all Artificial intelligence types
 	 * @post retrieves a list of ai players
 	 * @throws IOException
 	 */
-	void listAITypes() throws IOException;
+	AITypesContainer listAITypes() throws IOException;
 	
 	/**
 	 * Sends a request to the server to add an artificial intelligence player
@@ -323,7 +323,7 @@ public interface iServerProxy {
 	 * @post an AIPlayer is added to the game and given a color and the model is updated
 	 * @throws IOException
 	 */
-	void addAIPlayer() throws IOException;
+	void addAIPlayer(AIPlayer player) throws IOException;
 	
 	/**
 	 * Sends a request to server to change the log level

--- a/src/shared/models/AIPlayer.java
+++ b/src/shared/models/AIPlayer.java
@@ -1,0 +1,7 @@
+package shared.models;
+
+public class AIPlayer {
+
+	public AIPlayer() {}
+	
+}

--- a/src/shared/models/AITypesContainer.java
+++ b/src/shared/models/AITypesContainer.java
@@ -1,0 +1,10 @@
+package shared.models;
+
+import java.util.List;
+
+public class AITypesContainer {
+
+	private List<AIPlayer> players;
+	
+	public AITypesContainer() {}
+}

--- a/src/shared/models/CommandContainer.java
+++ b/src/shared/models/CommandContainer.java
@@ -1,0 +1,6 @@
+package shared.models;
+
+public class CommandContainer {
+
+	public CommandContainer() {}
+}


### PR DESCRIPTION
Proxy: added suitable model objects as return types to proxy functions that don’t return the whole model; replaced the arguments for offerTrade with TradeOffer object; changed the postCommands method to its description in the API. 
Serializer: expanded serializer to work with all return types, used in Proxy. 
Added CommandContainer, AITypesContainer, and AIPlayer classes that will be populated
