### PR TITLE
Modified turn tracker to not reinitialize the players every update

### DIFF
--- a/java/src/client/discard/DiscardController.java
+++ b/java/src/client/discard/DiscardController.java
@@ -245,12 +245,7 @@ public class DiscardController extends Controller
                 Map<ResourceType, Integer> playerHand = 
                         facade.getResources(localIndex);
                 hand = playerHand;
-//                for (Map.Entry<ResourceType, Integer> entry : hand.entrySet()) {
-//                    System.out.println(entry.getKey() + ": " + entry.getValue());
-//                }
-                System.out.println(facade.getState());
-                System.out.println("Total cards: " + getTotalHand());
-                System.out.println("Discarded: " + localPlayer.getDiscarded() + "\n");
+                
                 if (facade.getState().equals("Discarding") 
                         && this.getTotalHand() > 7
                         && !localPlayer.getDiscarded()) {

--- a/java/src/client/turntracker/TurnTrackerView.java
+++ b/java/src/client/turntracker/TurnTrackerView.java
@@ -115,7 +115,9 @@ public class TurnTrackerView extends PanelView implements ITurnTrackerView {
             boolean largestArmy, boolean longestRoad) {
         playerArmy[playerIndex].setVisible(largestArmy);
         playerRoad[playerIndex].setVisible(longestRoad);
+        playerPoints[playerIndex].setText("");
         playerPoints[playerIndex].setText(String.format("%d", points));
+//        playerPoints[playerIndex].setOpaque(true);        
 
         if (highlight) {
             playerPanel[playerIndex].setBorder(BorderFactory.createLineBorder(new Color(0, 0, 0), 3));


### PR DESCRIPTION
Fixes 3 bugs:
1) When it is not your turn you can no click the finish turn button.
2) When it is not your turn you can no longer end somebody else's turn (obviously related)
3) The turn tracker now properly update the points for players and the longest road award.
